### PR TITLE
Add LLM-friendly analysis module (PR 3)

### DIFF
--- a/sparkparse/analyze.py
+++ b/sparkparse/analyze.py
@@ -1,0 +1,268 @@
+"""LLM-friendly analysis and programmatic helpers for Spark execution logs."""
+
+import json
+from typing import Any
+
+import polars as pl
+
+from sparkparse.models import NodeType, ParsedLogDataFrames
+
+_JOIN_NODE_TYPES = frozenset(
+    [
+        NodeType.BroadcastHashJoin,
+        NodeType.SortMergeJoin,
+        NodeType.BroadcastNestedLoopJoin,
+    ]
+)
+
+
+def _detail_dict(details_str: str | None) -> dict[str, Any] | None:
+    """Return the 'detail' sub-dict from a node's details JSON, or None."""
+    if not details_str:
+        return None
+    try:
+        return json.loads(details_str).get("detail")
+    except (json.JSONDecodeError, AttributeError):
+        return None
+
+
+def to_plan_summary(dfs: ParsedLogDataFrames, log_name: str) -> dict[str, Any]:
+    """
+    Return a token-efficient dict of execution plan data for LLM analysis.
+
+    Presents raw facts (nodes, durations, bytes, join types, paths) without
+    pre-assigned severity. The value over df.explain() is runtime metrics
+    (per-node durations correlated from accumulator updates).
+    """
+    dag = dfs.dag
+    combined = dfs.combined
+
+    queries: list[dict[str, Any]] = []
+    for query_id in dag["query_id"].unique().sort().to_list():
+        qdf = dag.filter(pl.col("query_id") == query_id)
+        first = qdf.row(0, named=True)
+
+        nodes = []
+        for row in qdf.sort("node_id").to_dicts():
+            acc_totals = row.get("accumulator_totals") or []
+            metrics = [
+                {"name": m["metric_name"], "value": m["readable_str"]}
+                for m in acc_totals
+                if isinstance(m, dict)
+            ]
+
+            detail = _detail_dict(row.get("details"))
+            node_detail: dict[str, Any] | None = None
+            if detail is not None:
+                nt = row["node_type"]
+                if nt == NodeType.Scan:
+                    loc = detail.get("location", {})
+                    node_detail = {
+                        "paths": loc.get("location", []),
+                        "read_schema": detail.get("read_schema"),
+                    }
+                elif nt in (NodeType.BroadcastHashJoin, NodeType.SortMergeJoin):
+                    node_detail = {
+                        "join_type": detail.get("join_type"),
+                        "left_keys": detail.get("left_keys"),
+                        "right_keys": detail.get("right_keys"),
+                        "join_condition": detail.get("join_condition"),
+                    }
+                elif nt == NodeType.BroadcastNestedLoopJoin:
+                    node_detail = {
+                        "join_type": detail.get("join_type"),
+                        "join_condition": detail.get("join_condition"),
+                    }
+
+            entry: dict[str, Any] = {
+                "node_id": row["node_id"],
+                "node_type": row["node_type"],
+                "node_name": row["node_name"],
+                "child_nodes": row.get("child_nodes"),
+                "duration_minutes": row["node_duration_minutes"],
+                "metrics": metrics,
+            }
+            if node_detail is not None:
+                entry["details"] = node_detail
+            nodes.append(entry)
+
+        queries.append(
+            {
+                "query_id": query_id,
+                "query_function": first["query_function"],
+                "start": first["query_start_timestamp"],
+                "end": first["query_end_timestamp"],
+                "duration_seconds": first["query_duration_seconds"],
+                "nodes": nodes,
+            }
+        )
+
+    agg = combined.select(
+        pl.sum("bytes_read").alias("bytes_read"),
+        pl.sum("records_read").alias("records_read"),
+        pl.sum("bytes_written").alias("bytes_written"),
+        pl.sum("records_written").alias("records_written"),
+        pl.sum("memory_bytes_spilled").alias("memory_bytes_spilled"),
+        pl.sum("disk_bytes_spilled").alias("disk_bytes_spilled"),
+        pl.sum("shuffle_bytes_read").alias("shuffle_bytes_read"),
+        pl.sum("shuffle_bytes_written").alias("shuffle_bytes_written"),
+        pl.sum("executor_run_time_seconds").alias("executor_run_time_seconds"),
+        pl.sum("jvm_gc_time_seconds").alias("jvm_gc_time_seconds"),
+    ).row(0, named=True)
+
+    return {
+        "log_name": log_name,
+        "queries": queries,
+        "totals": agg,
+    }
+
+
+def find_cartesian_joins(dfs: ParsedLogDataFrames) -> pl.DataFrame:
+    """
+    Return DAG nodes that are cartesian or cross joins.
+
+    Includes BroadcastNestedLoopJoin and any hash/merge join with join_type=Cross.
+    """
+    dag = dfs.dag
+
+    bnlj_mask = pl.col("node_type") == NodeType.BroadcastNestedLoopJoin
+
+    cross_ids: list[int] = []
+    for row in dag.filter(
+        pl.col("node_type").is_in([NodeType.BroadcastHashJoin, NodeType.SortMergeJoin])
+    ).to_dicts():
+        detail = _detail_dict(row.get("details"))
+        if detail and detail.get("join_type") == "Cross":
+            cross_ids.append(row["node_id"])
+
+    cross_mask = pl.col("node_id").is_in(cross_ids) if cross_ids else pl.lit(False)
+
+    return (
+        dag.filter(bnlj_mask | cross_mask)
+        .select(
+            "query_id",
+            "node_id",
+            "node_name",
+            "node_type",
+            "details",
+            "node_duration_minutes",
+        )
+        .sort("query_id", "node_id")
+    )
+
+
+def find_largest_scans(dfs: ParsedLogDataFrames, n: int = 10) -> pl.DataFrame:
+    """
+    Return the top N scan nodes by total bytes read.
+
+    Correlates scan nodes to task-level bytes_read via the nodes list in combined.
+    """
+    dag = dfs.dag
+    combined = dfs.combined
+
+    scan_nodes = dag.filter(pl.col("node_type") == NodeType.Scan)
+    if scan_nodes.is_empty():
+        return pl.DataFrame(
+            schema={
+                "query_id": pl.Int64,
+                "node_id": pl.Int64,
+                "node_name": pl.String,
+                "paths": pl.List(pl.String),
+                "bytes_read": pl.Int64,
+                "records_read": pl.Int64,
+                "node_duration_minutes": pl.Float64,
+            }
+        )
+
+    node_bytes = (
+        combined.select("query_id", "nodes", "bytes_read", "records_read")
+        .explode("nodes")
+        .rename({"nodes": "node_name"})
+        .group_by("query_id", "node_name")
+        .agg(
+            pl.sum("bytes_read").alias("bytes_read"),
+            pl.sum("records_read").alias("records_read"),
+        )
+    )
+
+    return (
+        scan_nodes.select(
+            "query_id", "node_id", "node_name", "details", "node_duration_minutes"
+        )
+        .join(node_bytes, on=["query_id", "node_name"], how="left")
+        .with_columns(
+            pl.col("details")
+            .map_elements(
+                lambda s: json.loads(s)["detail"]["location"]["location"]
+                if s is not None
+                else [],
+                return_dtype=pl.List(pl.String),
+            )
+            .alias("paths")
+        )
+        .drop("details")
+        .sort("bytes_read", descending=True)
+        .head(n)
+    )
+
+
+def find_repeated_scans(dfs: ParsedLogDataFrames) -> pl.DataFrame:
+    """
+    Return scan paths read more than once across queries.
+
+    Repeated scans are candidates for caching with DataFrame.cache() / persist().
+    """
+    dag = dfs.dag
+    scan_nodes = dag.filter(pl.col("node_type") == NodeType.Scan)
+
+    empty = pl.DataFrame(
+        schema={
+            "path": pl.String,
+            "scan_count": pl.UInt32,
+            "query_ids": pl.List(pl.Int64),
+        }
+    )
+
+    if scan_nodes.is_empty():
+        return empty
+
+    records: list[dict[str, Any]] = []
+    for row in scan_nodes.to_dicts():
+        detail = _detail_dict(row.get("details"))
+        if not detail:
+            continue
+        for path in detail.get("location", {}).get("location", []):
+            records.append({"path": path, "query_id": row["query_id"]})
+
+    if not records:
+        return empty
+
+    return (
+        pl.DataFrame(records)
+        .unique()
+        .group_by("path")
+        .agg(
+            pl.len().alias("scan_count"),
+            pl.col("query_id").alias("query_ids"),
+        )
+        .filter(pl.col("scan_count") > 1)
+        .sort("scan_count", descending=True)
+    )
+
+
+def find_spill(dfs: ParsedLogDataFrames) -> pl.DataFrame:
+    """
+    Return query/stage combinations with non-zero memory or disk spill.
+    """
+    return (
+        dfs.combined.filter(
+            (pl.col("memory_bytes_spilled") > 0) | (pl.col("disk_bytes_spilled") > 0)
+        )
+        .group_by("query_id", "stage_id")
+        .agg(
+            pl.sum("memory_bytes_spilled").alias("memory_bytes_spilled"),
+            pl.sum("disk_bytes_spilled").alias("disk_bytes_spilled"),
+            pl.len().alias("task_count"),
+        )
+        .sort("memory_bytes_spilled", descending=True)
+    )

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -1,0 +1,263 @@
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from sparkparse.analyze import (
+    find_cartesian_joins,
+    find_largest_scans,
+    find_repeated_scans,
+    find_spill,
+    to_plan_summary,
+)
+from sparkparse.clean import log_to_combined_df, log_to_dag_df
+from sparkparse.models import NodeType, ParsedLogDataFrames
+from sparkparse.parse import parse_log
+
+DATA_DIR = Path(__file__).parent / "data" / "full_logs"
+
+
+@pytest.fixture(scope="module")
+def dfs_nested() -> ParsedLogDataFrames:
+    log_path = DATA_DIR / "nested_final_plans"
+    result = parse_log(log_path)
+    dag = log_to_dag_df(result)
+    combined = log_to_combined_df(result, dag, log_path.stem)
+    return ParsedLogDataFrames(dag=dag, combined=combined)
+
+
+@pytest.fixture(scope="module")
+def dfs_loop_join() -> ParsedLogDataFrames:
+    log_path = DATA_DIR / "nested_loop_join"
+    result = parse_log(log_path)
+    dag = log_to_dag_df(result)
+    combined = log_to_combined_df(result, dag, log_path.stem)
+    return ParsedLogDataFrames(dag=dag, combined=combined)
+
+
+@pytest.fixture(scope="module")
+def dfs_complex() -> ParsedLogDataFrames:
+    log_path = DATA_DIR / "complex_transformation_medium"
+    result = parse_log(log_path)
+    dag = log_to_dag_df(result)
+    combined = log_to_combined_df(result, dag, log_path.stem)
+    return ParsedLogDataFrames(dag=dag, combined=combined)
+
+
+# ---------------------------------------------------------------------------
+# to_plan_summary
+# ---------------------------------------------------------------------------
+
+
+def test_to_plan_summary_top_level_keys(dfs_nested):
+    summary = to_plan_summary(dfs_nested, "nested_final_plans")
+    assert summary["log_name"] == "nested_final_plans"
+    assert "queries" in summary
+    assert "totals" in summary
+    assert len(summary["queries"]) > 0
+
+
+def test_to_plan_summary_query_structure(dfs_nested):
+    summary = to_plan_summary(dfs_nested, "nested_final_plans")
+    query = summary["queries"][0]
+    for key in (
+        "query_id",
+        "query_function",
+        "start",
+        "end",
+        "duration_seconds",
+        "nodes",
+    ):
+        assert key in query
+    assert len(query["nodes"]) > 0
+
+
+def test_to_plan_summary_node_structure(dfs_nested):
+    summary = to_plan_summary(dfs_nested, "nested_final_plans")
+    node = summary["queries"][0]["nodes"][0]
+    for key in ("node_id", "node_type", "node_name", "duration_minutes", "metrics"):
+        assert key in node
+
+
+def test_to_plan_summary_scan_details(dfs_nested):
+    summary = to_plan_summary(dfs_nested, "nested_final_plans")
+    scan_nodes = [
+        n
+        for q in summary["queries"]
+        for n in q["nodes"]
+        if n["node_type"] == NodeType.Scan and "details" in n
+    ]
+    assert len(scan_nodes) > 0
+    detail = scan_nodes[0]["details"]
+    assert "paths" in detail
+    assert "read_schema" in detail
+    assert isinstance(detail["paths"], list)
+
+
+def test_to_plan_summary_totals_keys(dfs_nested):
+    totals = to_plan_summary(dfs_nested, "nested_final_plans")["totals"]
+    for key in (
+        "bytes_read",
+        "records_read",
+        "memory_bytes_spilled",
+        "disk_bytes_spilled",
+        "shuffle_bytes_read",
+        "shuffle_bytes_written",
+        "executor_run_time_seconds",
+        "jvm_gc_time_seconds",
+    ):
+        assert key in totals
+
+
+def test_to_plan_summary_totals_non_negative(dfs_nested):
+    totals = to_plan_summary(dfs_nested, "nested_final_plans")["totals"]
+    for key, val in totals.items():
+        assert val >= 0, f"{key} should be non-negative, got {val}"
+
+
+def test_to_plan_summary_node_metrics_structure(dfs_nested):
+    summary = to_plan_summary(dfs_nested, "nested_final_plans")
+    nodes_with_metrics = [
+        n for q in summary["queries"] for n in q["nodes"] if n["metrics"]
+    ]
+    assert len(nodes_with_metrics) > 0
+    metric = nodes_with_metrics[0]["metrics"][0]
+    assert "name" in metric
+    assert "value" in metric
+
+
+# ---------------------------------------------------------------------------
+# find_cartesian_joins
+# ---------------------------------------------------------------------------
+
+
+def test_find_cartesian_joins_returns_dataframe(dfs_nested):
+    result = find_cartesian_joins(dfs_nested)
+    assert isinstance(result, pl.DataFrame)
+
+
+def test_find_cartesian_joins_columns(dfs_nested):
+    result = find_cartesian_joins(dfs_nested)
+    assert set(result.columns) >= {
+        "query_id",
+        "node_id",
+        "node_name",
+        "node_type",
+        "node_duration_minutes",
+    }
+
+
+def test_find_cartesian_joins_detects_bnlj(dfs_loop_join):
+    result = find_cartesian_joins(dfs_loop_join)
+    assert result.shape[0] > 0
+    assert (result["node_type"] == NodeType.BroadcastNestedLoopJoin).any()
+
+
+def test_find_cartesian_joins_only_join_types(dfs_loop_join):
+    result = find_cartesian_joins(dfs_loop_join)
+    allowed = {
+        NodeType.BroadcastNestedLoopJoin,
+        NodeType.BroadcastHashJoin,
+        NodeType.SortMergeJoin,
+    }
+    assert set(result["node_type"].to_list()).issubset(allowed)
+
+
+# ---------------------------------------------------------------------------
+# find_largest_scans
+# ---------------------------------------------------------------------------
+
+
+def test_find_largest_scans_returns_dataframe(dfs_nested):
+    result = find_largest_scans(dfs_nested)
+    assert isinstance(result, pl.DataFrame)
+
+
+def test_find_largest_scans_columns(dfs_nested):
+    result = find_largest_scans(dfs_nested)
+    assert set(result.columns) >= {
+        "query_id",
+        "node_id",
+        "node_name",
+        "paths",
+        "bytes_read",
+        "records_read",
+        "node_duration_minutes",
+    }
+
+
+def test_find_largest_scans_n_limit(dfs_complex):
+    for n in (1, 3, 5):
+        result = find_largest_scans(dfs_complex, n=n)
+        assert result.shape[0] <= n
+
+
+def test_find_largest_scans_sorted_descending(dfs_complex):
+    result = find_largest_scans(dfs_complex, n=10)
+    if result.shape[0] > 1:
+        vals = result["bytes_read"].drop_nulls().to_list()
+        assert vals == sorted(vals, reverse=True)
+
+
+def test_find_largest_scans_paths_are_lists(dfs_nested):
+    result = find_largest_scans(dfs_nested)
+    assert result["paths"].dtype == pl.List(pl.String)
+
+
+# ---------------------------------------------------------------------------
+# find_repeated_scans
+# ---------------------------------------------------------------------------
+
+
+def test_find_repeated_scans_returns_dataframe(dfs_nested):
+    result = find_repeated_scans(dfs_nested)
+    assert isinstance(result, pl.DataFrame)
+
+
+def test_find_repeated_scans_columns(dfs_complex):
+    result = find_repeated_scans(dfs_complex)
+    if result.shape[0] > 0:
+        assert set(result.columns) >= {"path", "scan_count", "query_ids"}
+
+
+def test_find_repeated_scans_count_above_one(dfs_complex):
+    result = find_repeated_scans(dfs_complex)
+    if result.shape[0] > 0:
+        assert (result["scan_count"] > 1).all()
+
+
+def test_find_repeated_scans_sorted_descending(dfs_complex):
+    result = find_repeated_scans(dfs_complex)
+    if result.shape[0] > 1:
+        counts = result["scan_count"].to_list()
+        assert counts == sorted(counts, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# find_spill
+# ---------------------------------------------------------------------------
+
+
+def test_find_spill_returns_dataframe(dfs_nested):
+    result = find_spill(dfs_nested)
+    assert isinstance(result, pl.DataFrame)
+
+
+def test_find_spill_columns(dfs_nested):
+    result = find_spill(dfs_nested)
+    assert set(result.columns) >= {
+        "query_id",
+        "stage_id",
+        "memory_bytes_spilled",
+        "disk_bytes_spilled",
+        "task_count",
+    }
+
+
+def test_find_spill_no_zero_rows(dfs_nested):
+    result = find_spill(dfs_nested)
+    if result.shape[0] > 0:
+        has_spill = (result["memory_bytes_spilled"] > 0) | (
+            result["disk_bytes_spilled"] > 0
+        )
+        assert has_spill.all()


### PR DESCRIPTION
- sparkparse/analyze.py: to_plan_summary() builds a token-efficient dict
  of per-node runtime metrics (durations, scan paths, join types) correlated
  from accumulator updates; find_cartesian_joins(), find_largest_scans(),
  find_repeated_scans(), find_spill() for programmatic/notebook use
- tests/test_analyze.py: 23 tests covering structure, content, and edge cases
  across all three fixture logs

https://claude.ai/code/session_01K2vBStnakxoYEd85tQrjhZ